### PR TITLE
[FRONTEND] Update navbar styling

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -43,7 +43,7 @@ export default function Navbar({
 
   return (
     <nav
-      className={`relative flex flex-col h-screen bg-[#00A63E] shrink-0 overflow-visible transition-width duration-300 ease-in-out ${
+      className={`relative flex flex-col h-screen bg-[#00A63E] shrink-0 overflow-visible transition-[width] duration-300 ease-in-out ${
         isCollapsed ? "w-[105px]" : "w-[280px] xl:w-[360px]"
       }`}
     >
@@ -78,7 +78,7 @@ export default function Navbar({
         onClick={() => setIsCollapsed((prev) => !prev)}
         size="small"
         aria-label={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
-className="!absolute !top-[75px] !right-0 !translate-x-1/2 !z-50 !border-2 !border-[`#00A63E`] !text-[`#00A63E`] !bg-white !w-9 !h-9 hover:!bg-gray-100"
+        className="!absolute !top-[75px] !right-0 !translate-x-1/2 !z-50 !border-2 !border-[`#00A63E`] !text-[`#00A63E`] !bg-white !w-9 !h-9 hover:!bg-gray-100"
       >
         {isCollapsed ? (
           <ChevronRightIcon fontSize="small" />
@@ -133,7 +133,7 @@ className="!absolute !top-[75px] !right-0 !translate-x-1/2 !z-50 !border-2 !bord
 
       <div className="px-4 pb-6 flex flex-col gap-3">
         <Button
-        size="large"
+          size="large"
           variant="contained"
           startIcon={!isCollapsed && <AddIcon />}
           onClick={handleNewCampaign}


### PR DESCRIPTION
Files changed: navbar.tsx

Added min-max width based on screen size, altered buttons for Figma consistency, and standardized colors for hovers.
Low Width:
<img width="1242" height="809" alt="Screenshot 2026-02-26 at 1 03 36 PM" src="https://github.com/user-attachments/assets/ca4d80df-ac2f-42f3-bee8-2b00374a4a94" />
High Width:
<img width="1470" height="810" alt="Screenshot 2026-02-26 at 1 03 58 PM" src="https://github.com/user-attachments/assets/e7b8ab73-092d-4fe6-a151-5292b35dde62" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI/UX Improvements**
  * Smoother navbar width transitions and improved responsiveness between collapsed and expanded states
  * Clearer active campaign highlighting with stronger contrast and refined hover states
  * Larger, more accessible "New Campaign" control that shows an icon when collapsed and text when expanded
  * Logout label standardized to "LOG OUT" with subtle underline behavior on hover
  * General styling refinements for consistent alignment and visual tokens
<!-- end of auto-generated comment: release notes by coderabbit.ai -->